### PR TITLE
Decrease memory usage of Sourcemap Devtool code

### DIFF
--- a/lib/SourceMapDevToolPlugin.js
+++ b/lib/SourceMapDevToolPlugin.js
@@ -38,128 +38,126 @@ SourceMapDevToolPlugin.prototype.apply = function(compiler) {
 		compilation.plugin("after-optimize-chunk-assets", function(chunks) {
 			var allModules = [];
 			var allModuleFilenames = [];
-			var tasks = [];
-			chunks.forEach(function(chunk) {
-				chunk.files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options)).map(function(file) {
-					var asset = this.assets[file];
-					if(asset.__SourceMapDevToolData) {
-						var data = asset.__SourceMapDevToolData;
-						for(var cachedFile in data) {
-							this.assets[cachedFile] = data[cachedFile];
-							if(cachedFile !== file)
-								chunk.files.push(cachedFile);
+			function getSourceAndMap(asset) {
+				var source;
+				var sourceMap;
+				if(asset.sourceAndMap) {
+					var sourceAndMap = asset.sourceAndMap(options);
+					sourceMap = sourceAndMap.map;
+					source = sourceAndMap.source;
+				} else {
+					sourceMap = asset.map(options);
+					source = asset.source();
+				}
+
+				return {source: source, sourceMap: sourceMap};
+			}
+			function getModulesWithFilenames(sourceMap) {
+				var modules = sourceMap.sources.map(function(source) {
+					var module = compilation.findModule(source);
+					return module || source;
+				});
+				var moduleFilenames = modules.map(function(module) {
+					return ModuleFilenameHelpers.createFilename(module, moduleFilenameTemplate, requestShortener);
+				});
+
+				return {modules: modules, moduleFilenames: moduleFilenames}
+			}
+
+			var outputPath = this.getPath(compiler.outputPath);
+			compiler.outputFileSystem.mkdirp(outputPath, function() {
+				chunks.forEach(function(chunk) {
+					var files = chunk.files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options))
+					files.forEach(function(file) {
+						var {source, sourceMap} = getSourceAndMap(this.assets[file]);
+						if(sourceMap) {
+							var {modules, moduleFilenames} = getModulesWithFilenames(sourceMap);
+							allModules = allModules.concat(modules);
+							allModuleFilenames = allModuleFilenames.concat(moduleFilenames);
 						}
-						return;
-					}
-					var source;
-					var sourceMap;
-					if(asset.sourceAndMap) {
-						var sourceAndMap = asset.sourceAndMap(options);
-						sourceMap = sourceAndMap.map;
-						source = sourceAndMap.source;
-					} else {
-						sourceMap = asset.map(options);
-						source = asset.source();
-					}
-					if(sourceMap) {
-						return {
-							chunk: chunk,
-							file: file,
-							asset: asset,
-							source: source,
-							sourceMap: sourceMap
-						};
-					}
-				}, this).filter(Boolean).map(function(task) {
-					var modules = task.sourceMap.sources.map(function(source) {
-						var module = compilation.findModule(source);
-						return module || source;
+					}, this);
+					allModuleFilenames = ModuleFilenameHelpers.replaceDuplicates(allModuleFilenames, function(filename, i) {
+						return ModuleFilenameHelpers.createFilename(allModules[i], fallbackModuleFilenameTemplate, requestShortener);
+					}, function(ai, bi) {
+						var a = allModules[ai];
+						var b = allModules[bi];
+						a = !a ? "" : typeof a === "string" ? a : a.identifier();
+						b = !b ? "" : typeof b === "string" ? b : b.identifier();
+						return a.length - b.length;
 					});
-					var moduleFilenames = modules.map(function(module) {
-						return ModuleFilenameHelpers.createFilename(module, moduleFilenameTemplate, requestShortener);
+					allModuleFilenames = ModuleFilenameHelpers.replaceDuplicates(allModuleFilenames, function(filename, i, n) {
+						for(var j = 0; j < n; j++)
+							filename += "*";
+						return filename;
 					});
-					task.modules = modules;
-					task.moduleFilenames = moduleFilenames;
-					return task;
-				}, this).forEach(function(task) {
-					allModules = allModules.concat(task.modules);
-					allModuleFilenames = allModuleFilenames.concat(task.moduleFilenames);
-					tasks.push(task);
+					files.forEach(function(file) {
+						var asset = this.assets[file];
+						var {source, sourceMap} = getSourceAndMap(asset);
+						if(sourceMap) {
+							var {modules, moduleFilenames} = getModulesWithFilenames(sourceMap);
+							moduleFilenames = allModuleFilenames.slice(0, moduleFilenames.length);
+							allModuleFilenames = allModuleFilenames.slice(moduleFilenames.length);
+							modules = modules.slice(0, moduleFilenames.length);
+							allModules = allModules.slice(moduleFilenames.length);
+							sourceMap.sources = moduleFilenames;
+							if(sourceMap.sourcesContent && !options.noSources) {
+								sourceMap.sourcesContent = sourceMap.sourcesContent.map(function(content, i) {
+									return content + "\n\n\n" + ModuleFilenameHelpers.createFooter(modules[i], requestShortener);
+								});
+							} else {
+								sourceMap.sourcesContent = undefined;
+							}
+							sourceMap.sourceRoot = options.sourceRoot || "";
+							var currentSourceMappingURLComment = sourceMappingURLComment;
+							if(currentSourceMappingURLComment !== false && /\.css($|\?)/i.test(file)) {
+								currentSourceMappingURLComment = currentSourceMappingURLComment.replace(/^\n\/\/(.*)$/, "\n/*$1*/");
+							}
+							if(sourceMapFilename) {
+								var filename = file,
+									query = "";
+								var idx = filename.indexOf("?");
+								if(idx >= 0) {
+									query = filename.substr(idx);
+									filename = filename.substr(0, idx);
+								}
+								var sourceMapFile = this.getPath(sourceMapFilename, {
+									chunk: chunk,
+									filename: filename,
+									query: query,
+									basename: basename(filename)
+								});
+								var sourceMapUrl = path.relative(path.dirname(file), sourceMapFile).replace(/\\/g, "/");
+								if(currentSourceMappingURLComment !== false) {
+									delete this.assets[file];
+									this.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment.replace(/\[url\]/g, sourceMapUrl));
+								}
+								var sourceMapContent= new RawSource(JSON.stringify(sourceMap));
+								var content = sourceMapContent.source();
+
+								if(!Buffer.isBuffer(content)) {
+									content = new Buffer(content, "utf8"); //eslint-disable-line
+								}
+
+								delete sourceMapContent;
+								var targetPath = compiler.outputFileSystem.join(outputPath, sourceMapFile);
+								compiler.outputFileSystem.writeFile(targetPath, content);
+								chunk.files.push(sourceMapFile);
+							} else {
+								this.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment
+									.replace(/\[map\]/g, function() {
+										return JSON.stringify(sourceMap);
+									})
+									.replace(/\[url\]/g, function() {
+										return "data:application/json;charset=utf-8;base64," +
+											new Buffer(JSON.stringify(sourceMap), "utf8").toString("base64"); //eslint-disable-line
+									})
+								);
+							}
+							sourceMap.file = file;
+						}
+					}, this);
 				}, this);
-			}, this);
-			allModuleFilenames = ModuleFilenameHelpers.replaceDuplicates(allModuleFilenames, function(filename, i) {
-				return ModuleFilenameHelpers.createFilename(allModules[i], fallbackModuleFilenameTemplate, requestShortener);
-			}, function(ai, bi) {
-				var a = allModules[ai];
-				var b = allModules[bi];
-				a = !a ? "" : typeof a === "string" ? a : a.identifier();
-				b = !b ? "" : typeof b === "string" ? b : b.identifier();
-				return a.length - b.length;
-			});
-			allModuleFilenames = ModuleFilenameHelpers.replaceDuplicates(allModuleFilenames, function(filename, i, n) {
-				for(var j = 0; j < n; j++)
-					filename += "*";
-				return filename;
-			});
-			tasks.forEach(function(task) {
-				task.moduleFilenames = allModuleFilenames.slice(0, task.moduleFilenames.length);
-				allModuleFilenames = allModuleFilenames.slice(task.moduleFilenames.length);
-			}, this);
-			tasks.forEach(function(task) {
-				var chunk = task.chunk;
-				var file = task.file;
-				var asset = task.asset;
-				var sourceMap = task.sourceMap;
-				var source = task.source;
-				var moduleFilenames = task.moduleFilenames;
-				var modules = task.modules;
-				sourceMap.sources = moduleFilenames;
-				if(sourceMap.sourcesContent && !options.noSources) {
-					sourceMap.sourcesContent = sourceMap.sourcesContent.map(function(content, i) {
-						return content + "\n\n\n" + ModuleFilenameHelpers.createFooter(modules[i], requestShortener);
-					});
-				} else {
-					sourceMap.sourcesContent = undefined;
-				}
-				sourceMap.sourceRoot = options.sourceRoot || "";
-				sourceMap.file = file;
-				asset.__SourceMapDevToolData = {};
-				var currentSourceMappingURLComment = sourceMappingURLComment;
-				if(currentSourceMappingURLComment !== false && /\.css($|\?)/i.test(file)) {
-					currentSourceMappingURLComment = currentSourceMappingURLComment.replace(/^\n\/\/(.*)$/, "\n/*$1*/");
-				}
-				if(sourceMapFilename) {
-					var filename = file,
-						query = "";
-					var idx = filename.indexOf("?");
-					if(idx >= 0) {
-						query = filename.substr(idx);
-						filename = filename.substr(0, idx);
-					}
-					var sourceMapFile = this.getPath(sourceMapFilename, {
-						chunk: chunk,
-						filename: filename,
-						query: query,
-						basename: basename(filename)
-					});
-					var sourceMapUrl = path.relative(path.dirname(file), sourceMapFile).replace(/\\/g, "/");
-					if(currentSourceMappingURLComment !== false) {
-						asset.__SourceMapDevToolData[file] = this.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment.replace(/\[url\]/g, sourceMapUrl));
-					}
-					asset.__SourceMapDevToolData[sourceMapFile] = this.assets[sourceMapFile] = new RawSource(JSON.stringify(sourceMap));
-					chunk.files.push(sourceMapFile);
-				} else {
-					asset.__SourceMapDevToolData[file] = this.assets[file] = new ConcatSource(new RawSource(source), currentSourceMappingURLComment
-						.replace(/\[map\]/g, function() {
-							return JSON.stringify(sourceMap);
-						})
-						.replace(/\[url\]/g, function() {
-							return "data:application/json;charset=utf-8;base64," +
-								new Buffer(JSON.stringify(sourceMap), "utf8").toString("base64"); //eslint-disable-line
-						})
-					);
-				}
-			}, this);
+			}.bind(this));
 		});
 	});
 };


### PR DESCRIPTION
Decreases heap usage of SourceMapDevTool code. With a 5gb the speed performance of our build is still effected. A customer page build takes like 15 min

THIS IS SUPER DIRTY SO DONT JUDGE ME ON STYLE. I really just want opinions on these changes and if there is room to make this even faster/less memory